### PR TITLE
Update YAML to point to the "YAML Support by Red Hat" VSCode extension

### DIFF
--- a/_languages/yaml.md
+++ b/_languages/yaml.md
@@ -8,11 +8,11 @@ highlighting_language: yaml
 description_blurb: is a powerful data serialization language that aims to be human friendly.  Most JSON is syntactically valid YAML, but idiomatic YAML follows very different conventions.  While YAML has advanced features that cannot be directly mapped to JSON, most YAML files use features that can be validated by JSON Schema.  JSON Schema is the most portable and broadly supported choice for YAML validation.
 editors:
   - name: Visual Studio Code
-    project_url: https://marketplace.visualstudio.com/items?itemName=adamvoss.yaml
+    project_url: https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml
     features:
       validation: true
       error_highlighting: true
-      completion: false
+      completion: true
 validators:
   - name: Polyglottal JSON Schema Validator
     project_url: https://www.npmjs.com/package/pajv


### PR DESCRIPTION
The [YAML Support by Red Hat](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml#overview) VSCode extension is now the most popular and full-featured. This updates the YAML page to point to that instead, and updates the feature support.