### PR TITLE
Added info about IntelliJ support for YAML schema (#4)

### DIFF
--- a/_languages/yaml.md
+++ b/_languages/yaml.md
@@ -13,6 +13,12 @@ editors:
       validation: true
       error_highlighting: true
       completion: true
+  - name: IntelliJ based IDEs
+    project_url: https://www.jetbrains.com/
+    features:
+      validation: true
+      error_highlighting: true
+      completion: true
 validators:
   - name: Polyglottal JSON Schema Validator
     project_url: https://www.npmjs.com/package/pajv


### PR DESCRIPTION
As stated in #4 all IntelliJ based IDEs (PhpStorm, WebStorm, PyCharm, IntelliJ IDEA, etc) support JSON Schema validation (including completion) for YAML files.