### PR TITLE
Update hjson url .md

### DIFF
--- a/_languages/hjson.md
+++ b/_languages/hjson.md
@@ -2,7 +2,7 @@
 title: Schema Validation for Hjson
 short_name: Hjson
 long_name: Hjson, a user interface for JSON
-project_url: http://hjson.org/
+project_url: https://hjson.github.io/
 logo: hjson.svg
 highlighting_language: hjson
 description_blurb: adds new language features and relaxes syntax restrictions aiming to make information entry easier and less error prone. Hjson only intends to be an intermediary between humans and JSON, as such the clear schema language is JSON Schema.


### PR DESCRIPTION
The old url (now) refers to a casino website (seemingly) unrelated to the hjson website. 